### PR TITLE
去掉columns中的空格

### DIFF
--- a/canal-client/src/main/java/com/tqmall/search/canal/Schemas.java
+++ b/canal-client/src/main/java/com/tqmall/search/canal/Schemas.java
@@ -242,14 +242,26 @@ public final class Schemas {
 
         public TableBuilder columns(String... columns) {
             if (columns.length > 0) {
-                Collections.addAll(this.columns, columns);
+                for (String element : columns) {
+                    if (StringUtils.isBlank(element)) {
+                        continue;
+                    }
+                    this.columns.add(element.trim());
+                }
+//                Collections.addAll(this.columns, columns);
             }
             return this;
         }
 
         public TableBuilder columns(Collection<String> columns) {
             if (!CommonsUtils.isEmpty(columns)) {
-                this.columns.addAll(columns);
+//                this.columns.addAll(columns);
+                for (String element : columns) {
+                    if (StringUtils.isBlank(element)) {
+                        continue;
+                    }
+                    this.columns.add(element.trim());
+                }
             }
             return this;
         }


### PR DESCRIPTION
因为在spring配置文件的时候，习惯在逗号后加一个空格，如下
<entry key="tableName" value="id, goods_id, goods_number"/>
所以在使用逗号作为隔符解析的时候 .columns(fieldNames.split(","));，列名前会有空格导致与数据库的字段不同，不能达到下面的效果
 .columns("id", "goods_id", "goods_number")

所以作了一点修改：
        public TableBuilder columns(String... columns) {
            if (columns.length > 0) {
                for (String element : columns) {
                    if (StringUtils.isBlank(element)) {
                        continue;
                    }
                    this.columns.add(element.trim());
                }
//                Collections.addAll(this.columns, columns);
            }
            return this;
        }

        public TableBuilder columns(Collection<String> columns) {
            if (!CommonsUtils.isEmpty(columns)) {
//                this.columns.addAll(columns);
                for (String element : columns) {
                    if (StringUtils.isBlank(element)) {
                        continue;
                    }
                    this.columns.add(element.trim());
                }
            }
            return this;
        }